### PR TITLE
Golang.yaml: Adds new language definition

### DIFF
--- a/data/Language/Golang.yaml
+++ b/data/Language/Golang.yaml
@@ -1,0 +1,43 @@
+identifier: Go
+wikidata: Q37227
+aliases:
+  - golang
+extensions:
+  - go
+line_continuation: '.'
+delimiters:
+  # comment delimiters
+  - double_slash
+  - multiline_slash_star
+  # string delimiters:
+  - double_quote_slash_escape
+  - curly_braces
+  - round_braces
+  - square_braces
+  - backticks
+keywords:
+  - break
+  - case
+  - chan
+  - const
+  - continue
+  - default
+  - defer
+  - else
+  - fallthrough
+  - for
+  - if
+  - func
+  - go
+  - goto
+  - import
+  - interface
+  - map
+  - package
+  - range
+  - return
+  - select
+  - struct
+  - switch
+  - type
+  - var


### PR DESCRIPTION
Golang.yaml --> Adds new language definition named Golang

Source:
[coala/golang.py](https://github.com/coala/coala/blob/master/coalib/bearlib/languages/definitions/Golang.py)
[WikiData](https://www.wikidata.org/wiki/Wikidata:Main_Page)