### PR TITLE
DataType.yaml: Add precision attribute for floating points

### DIFF
--- a/models/DataType.yaml
+++ b/models/DataType.yaml
@@ -1,7 +1,8 @@
 keyword: String  # Keyword that identifies the type i.e. int, str
 # Integer attributes
-integer-min: String  # String representing minium integer or uncertain
+integer-min: String  # String representing minimum integer or uncertain
 integer-max: String  # String represetinng maximum integer or uncertain
 integer-signed: Boolean  # Whether the datatype is signed integer or not
 delimiters: Delimiter[]  # If the datatype has any delimiters
 literals: Keyword[]  # List of literals for a datatype
+precision: Integer  # Integer representing precision of floating point types.


### PR DESCRIPTION
Add precision attribute for data types like float, double, etc.

Updated #44 and #46 regarding this (_I had earlier rather erroneously used the attribute without adding it in this file_).