### PR TITLE
Verilog.yaml: Added (Simpler) Data Types

### DIFF
--- a/data/DataType/bit_vlog.yaml
+++ b/data/DataType/bit_vlog.yaml
@@ -1,0 +1,4 @@
+﻿keyword: bit
+integer-min: '0'
+integer-max: '1'
+integer-signed: false

--- a/data/DataType/byte_vlog.yaml
+++ b/data/DataType/byte_vlog.yaml
@@ -1,0 +1,4 @@
+﻿keyword: byte
+integer-min: '-128'
+integer-max: '127'
+integer-signed: true

--- a/data/DataType/integer_vlog.yaml
+++ b/data/DataType/integer_vlog.yaml
@@ -1,0 +1,4 @@
+﻿keyword: integer
+integer-min: '-2147483648'
+integer-max: '2147483647'
+integer-signed: true

--- a/data/DataType/long_vlog.yaml
+++ b/data/DataType/long_vlog.yaml
@@ -1,0 +1,4 @@
+keyword: longint
+integer-min: '–9223372036854775808'
+integer-max: '9223372036854775807'
+integer-signed: true

--- a/data/DataType/short_vlog.yaml
+++ b/data/DataType/short_vlog.yaml
@@ -1,0 +1,4 @@
+keyword: shortint
+integer-min: '-32768'
+integer-max: '32767'
+integer-signed: true

--- a/data/Language/Verilog.yaml
+++ b/data/Language/Verilog.yaml
@@ -153,15 +153,15 @@ keywords:
   - xnor
   - xor
 datatypes:
-  - shortint
-  - int
-  - longint
-  - byte
-  - bit
-  - logic
-  - reg
-  - integer
-  - real
-  - shortreal
-  - realtime
-  - time
+  - short_vlog
+  - int_32
+  - long_vlog
+  - byte_vlog
+  - bit_vlog
+  - logic_vlog
+  - reg_vlog
+  - integer_vlog
+  - real_vlog
+  - shortreal_vlog
+  - realtime_vlog
+  - time_vlog


### PR DESCRIPTION
Added bit, byte, integer, long, and
short Verilog data types, and used int_c
as it is a duplicate of Verilog functionality.
I don't really understand the rest of the data types,
as logic, reg, and wire have some implicit
declaration and hardware language voodoo
going on, and I don't really understand
time either. Help by someone who is experienced
w/ Verilog would help 😅