### PR TITLE
Fix Netlify error

### DIFF
--- a/data/Language/Pascal.yaml
+++ b/data/Language/Pascal.yaml
@@ -50,7 +50,7 @@ keywords:
   - not
   - object
   - of
-  - on
+  - 'on'
   - operator
   - or
   - packed

--- a/data/Language/VisualBasic.yaml
+++ b/data/Language/VisualBasic.yaml
@@ -95,7 +95,7 @@ keywords:
   - new
   - not
   - nothing
-  - on
+  - 'on'
   - open
   - optional
   - or


### PR DESCRIPTION
The keywords present in VisualBasic.yaml has a non string value `on`, which yaml thinks it as a boolean value and  replaces those keywords by `1` or `0`, thus failing the builds.