### PR TITLE
data/Language/VisualBasic.yaml : Reduce length of "grammar_file"

### DIFF
--- a/data/Language/VisualBasic.yaml
+++ b/data/Language/VisualBasic.yaml
@@ -2,7 +2,8 @@ identifier: Visual Basic
 full_name: Visual Basic
 creation_date: 1991
 wikidata: Q2378
-grammar_file: https://github.com/antlr/grammars-v4/blob/master/vb6/VisualBasic6.g4
+grammar_file: https://github.com/antlr/grammars-v4/blob/master/vb6/
+              VisualBasic6.g4
 aliases:
   - vb
 extensions:


### PR DESCRIPTION
The line length was exceeding the maximum limit.
Now the line is broken into two lines as done in other files.
This closes https://github.com/coala/coAST/issues/77